### PR TITLE
feat: Use robfig/cron to make it always run in the foreground

### DIFF
--- a/backup/backup.go
+++ b/backup/backup.go
@@ -26,7 +26,7 @@ func dumpDB(db string, dst string) (dumpPath string, name string, err error) {
 }
 
 func Backup() {
-	logger.Info("monodb-backup started.")
+	logger.Info("monodb-backup job started.")
 	notify.SendAlarm("Database backup started.", false)
 
 	dateNow = rightNow{
@@ -214,8 +214,8 @@ func Backup() {
 			}
 		}
 	}
-	logger.Info("monodb-backup finished.")
-	notify.SendAlarm("monodb-backup finished.", false)
+	logger.Info("monodb-backup job finished.")
+	notify.SendAlarm("monodb-backup job finished.", false)
 }
 
 func uploads(name, db, filePath string) {

--- a/config/config.sample.yml
+++ b/config/config.sample.yml
@@ -1,5 +1,6 @@
 backupDestination: /var/backups
 database: postgresql # or mysql - default is postgresql
+runEveryCron: "@every 1m" # run every minute
 databases: # all databases if empty
   - db1
   - db2

--- a/config/params.go
+++ b/config/params.go
@@ -19,6 +19,7 @@ type Params struct {
 	Rotation          Rotation
 	Remote            Remote
 	Cluster           Cluster
+	RunEveryCron      string
 	Notify            struct {
 		Email struct {
 			Enabled            bool

--- a/go.mod
+++ b/go.mod
@@ -32,6 +32,7 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/pelletier/go-toml/v2 v2.1.0 // indirect
+	github.com/robfig/cron v1.2.0 // indirect
 	github.com/rs/xid v1.5.0 // indirect
 	github.com/sagikazarmark/locafero v0.4.0 // indirect
 	github.com/sagikazarmark/slog-shim v0.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -60,6 +60,8 @@ github.com/pkg/sftp v1.13.6/go.mod h1:tz1ryNURKu77RL+GuCzmoJYxQczL3wLNNpPWagdg4Q
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/robfig/cron v1.2.0 h1:ZjScXvvxeQ63Dbyxy76Fj3AT3Ut0aKsyd2/tl3DTMuQ=
+github.com/robfig/cron v1.2.0/go.mod h1:JGuDeoQd7Z6yL4zQhZ3OPEVHB7fL6Ka6skscFHfmt2k=
 github.com/rogpeppe/go-internal v1.9.0 h1:73kH8U+JUqXU8lRuOHeVHaa/SZPifC7BkcraZVejAe8=
 github.com/rogpeppe/go-internal v1.9.0/go.mod h1:WtVeX8xhTBvf0smdhujwtBcq4Qrzq/fJaraNFVN+nFs=
 github.com/rs/xid v1.5.0 h1:mKX4bl4iPYJtEIxp6CYiUuLQ/8DYMoz0PUdtGgMFRVc=


### PR DESCRIPTION
This pull request adds the ability for monodb-backup to be always running on the foreground.
This allows easier daemonization and removes the need for an external dependency such as cron to run it.

The pull request adds a config option called `runEveryCron`, you can put a cron time here to execute it.
If this config option doesn't exist, the program will be launched in the same way as before.